### PR TITLE
Added CI pipeline to the project 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [main]
-    tags: ["v*"]
+    branches: main
+    tags: "v*"
   pull_request:
-    branches: ["*"]
+    branches: "*"
 
 jobs:
   push:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  push:
+    name: push
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          registry-url: https://registry.npmjs.org
+          cache: yarn
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn run build
+      - run: yarn run test
+
+      - name: Publish to NPM
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: yarn publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   "sideEffects": false,
   "scripts": {
     "prepack": "npm run build",
-    "build": "rollup -c",
+    "build": "rollup -c && npm run fmt",
     "test:unit": "karma start",
     "test:node": "mocha ./tests/node/main.mjs",
     "test:types": "tsc -p ./tests/tsconfig.json",
     "test:types:watch": "npm run test:types -- --watch",
-    "test": "npm run fmt_test && npm run build && npm run test:types && npm run test:unit && npm run test:node",
+    "test": "npm run fmt_test && npm run test:types && npm run test:unit && npm run test:node",
     "fmt": "prettier --write './*.{mjs,js,ts,md,json,html}' './{src,docs,tests}/{,**/}*.{mjs,js,ts,md,json,html}'",
     "fmt_test": "test $(prettier -l './*.{mjs,js,ts,md,json,html}' './{src,docs,tests}/{**/,}*.{mjs,js,ts,md,json,html}' | wc -l) -eq 0",
     "watchtest": "CHROME_ONLY=1 karma start --no-single-run"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comlink",
-  "version": "4.4.2",
+  "version": "1.0.0",
   "description": "Comlink makes WebWorkers enjoyable",
   "main": "dist/umd/comlink.js",
   "module": "dist/esm/comlink.mjs",
@@ -19,8 +19,8 @@
     "watchtest": "CHROME_ONLY=1 karma start --no-single-run"
   },
   "author": {
-    "name": "Surma",
-    "email": "surma@google.com"
+    "name": "Lichtblick",
+    "email": "lichtblick@bmwgroup.com"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Created and implemented a CI pipeline based on other projects associated with Lichtblick, it was tested on a fork before and ran successfully.

Removed build from the test script on package.json because, since the pipeline already calls yarn build before calling yarn test, including build inside test was redundant and unnecessary.