### PR TITLE
Fix publish action on CI pipeline

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches: main
-    tags: "v*"
+    tags: v*
   pull_request:
     branches: "*"
 


### PR DESCRIPTION
Removing quotes from tags key on CI pipeline because that's making it from not trigger when is created and pushed a new tag and therefore the pipeline wont run